### PR TITLE
git-branch-rebase-all: Check user preference for each branch

### DIFF
--- a/git-branch-rebase-all
+++ b/git-branch-rebase-all
@@ -9,17 +9,16 @@ fi
 PATTERN=$1
 
 BRANCHES=$(git branch --list $PATTERN* | rev | cut -d' ' -f1 | rev)
-printf "Following branches would be rebased\n$BRANCHES\n"
-read -p "Do you want to proceed? [Y/n]: " opt
-if [ $opt == "N" ] || [ $opt == "n" ]; then
-	exit
-fi
 
 git checkout main
 git-fetch-update
 
 for br in $BRANCHES; do
+	read -p "Rebase $br? [Y/n]: " opt
+	case $opt in
+	    [Nn]* ) echo "Skipping..."; continue;;
+	esac
 	git checkout $br
-	git rebase -i main
+	git rebase main
 done
 


### PR DESCRIPTION
For every branch matching the pattern, check with the user whether they would be rebase.

Also, remove interactive rebase flag.